### PR TITLE
Feature/backward compatibility php 7.4

### DIFF
--- a/Block/CreditCard/CcInfo.php
+++ b/Block/CreditCard/CcInfo.php
@@ -17,6 +17,7 @@ class CcInfo extends Info
      * @var string
      */
     protected $_template = 'Conekta_Payments::info/creditcard.phtml';
+    protected Config $_paymentConfig;
 
     /**
      * CcInfo construct
@@ -27,9 +28,10 @@ class CcInfo extends Info
      */
     public function __construct(
         Context $context,
-        protected Config $_paymentConfig,
+        Config $_paymentConfig,
         array $data = []
     ) {
+        $this->_paymentConfig = $_paymentConfig;
         parent::__construct($context, $data);
     }
 

--- a/Block/EmbedForm/EmbedFormInfo.php
+++ b/Block/EmbedForm/EmbedFormInfo.php
@@ -18,6 +18,7 @@ class EmbedFormInfo extends Info
      * @var string
      */
     protected $_template = 'Conekta_Payments::info/embedform.phtml';
+    protected Config $_paymentConfig;
 
     /**
      * EmbedFormInfo construct
@@ -28,9 +29,10 @@ class EmbedFormInfo extends Info
      */
     public function __construct(
         Context $context,
-        protected Config $_paymentConfig,
+        Config $_paymentConfig,
         array $data = []
     ) {
+        $this->_paymentConfig = $_paymentConfig;
         parent::__construct($context, $data);
     }
 

--- a/Block/Oxxo/OxxoInfo.php
+++ b/Block/Oxxo/OxxoInfo.php
@@ -13,6 +13,7 @@ use Magento\Payment\Model\Config;
 class OxxoInfo extends Info
 {
     protected $_template = 'Conekta_Payments::info/oxxo.phtml';
+    protected Config $_paymentConfig;
 
     /**
      * Construct OxxoInfo
@@ -23,9 +24,10 @@ class OxxoInfo extends Info
      */
     public function __construct(
         Context $context,
-        protected Config $_paymentConfig,
+        Config $_paymentConfig,
         array $data = []
     ) {
+        $this->_paymentConfig = $_paymentConfig;
         parent::__construct($context, $data);
     }
 

--- a/Block/Spei/SpeiInfo.php
+++ b/Block/Spei/SpeiInfo.php
@@ -13,6 +13,7 @@ use Magento\Payment\Model\Config;
 class SpeiInfo extends Info
 {
     protected $_template = 'Conekta_Payments::info/spei.phtml';
+    protected Config $_paymentConfig;
 
     /**
      * Construct SpeiInfo
@@ -23,9 +24,10 @@ class SpeiInfo extends Info
      */
     public function __construct(
         Context $context,
-        protected Config $_paymentConfig,
+        Config $_paymentConfig,
         array $data = []
     ) {
+        $this->_paymentConfig = $_paymentConfig;
         parent::__construct($context, $data);
     }
 

--- a/Controller/Index/CreateOrder.php
+++ b/Controller/Index/CreateOrder.php
@@ -16,6 +16,13 @@ use Magento\Framework\View\Result\PageFactory;
 
 class CreateOrder extends Action implements HttpPostActionInterface
 {
+    protected Logger $logger;
+    protected ConektaOrder $conektaOrderHelper;
+    protected JsonFactory $resultJsonFactory;
+    protected PageFactory $resultPageFactory;
+    private Session $checkoutSession;
+    private EmbedFormRepositoryInterface $embedFormRepository;
+
     /**
      * CreateOrder constructor
      *
@@ -29,13 +36,19 @@ class CreateOrder extends Action implements HttpPostActionInterface
      */
     public function __construct(
         Context                $context,
-        protected PageFactory  $resultPageFactory,
-        protected JsonFactory  $resultJsonFactory,
-        protected ConektaOrder $conektaOrderHelper,
-        protected Logger       $logger,
-        private                EmbedFormRepositoryInterface $embedFormRepository,
-        private Session        $checkoutSession
+        PageFactory  $resultPageFactory,
+        JsonFactory  $resultJsonFactory,
+        ConektaOrder $conektaOrderHelper,
+        Logger       $logger,
+        EmbedFormRepositoryInterface $embedFormRepository,
+        Session        $checkoutSession
     ) {
+        $this->resultPageFactory = $resultPageFactory;
+        $this->resultJsonFactory = $resultJsonFactory;
+        $this->conektaOrderHelper = $conektaOrderHelper;
+        $this->logger = $logger;
+        $this->embedFormRepository = $embedFormRepository;
+        $this->checkoutSession = $checkoutSession;
         parent::__construct($context);
     }
 

--- a/Controller/Router.php
+++ b/Controller/Router.php
@@ -15,6 +15,11 @@ use Magento\Framework\Url;
  */
 class Router implements RouterInterface
 {
+    protected ResponseInterface $_response;
+    protected ActionFactory $actionFactory;
+    private ConektaLogger $conektaLogger;
+    private ConektaHelper $conektaHelper;
+
     /**
      * Router construct
      *
@@ -24,11 +29,15 @@ class Router implements RouterInterface
      * @param ConektaLogger $conektaLogger
      */
     public function __construct(
-        protected ActionFactory $actionFactory,
-        protected ResponseInterface $_response,
-        private ConektaHelper $conektaHelper,
-        private ConektaLogger $conektaLogger
+        ActionFactory $actionFactory,
+        ResponseInterface $_response,
+        ConektaHelper $conektaHelper,
+        ConektaLogger $conektaLogger
     ) {
+        $this->actionFactory = $actionFactory;
+        $this->_response = $_response;
+        $this->conektaHelper = $conektaHelper;
+        $this->conektaLogger = $conektaLogger;
     }
 
     /**

--- a/Controller/Webhook/Index.php
+++ b/Controller/Webhook/Index.php
@@ -28,6 +28,12 @@ class Index extends Action implements CsrfAwareActionInterface
     public const EVENT_ORDER_PENDING_PAYMENT = 'order.pending_payment';
     public const EVENT_ORDER_PAID = 'order.paid';
     public const EVENT_ORDER_EXPIRED = 'order.expired';
+    protected Data $helper;
+    protected RawFactory $resultRawFactory;
+    protected JsonFactory $resultJsonFactory;
+    private WebhookRepository $webhookRepository;
+    private ConektaLogger $conektaLogger;
+    private Logger $logger;
 
     /**
      * Index Webhook contruct
@@ -42,13 +48,19 @@ class Index extends Action implements CsrfAwareActionInterface
      */
     public function __construct(
         Context $context,
-        protected JsonFactory $resultJsonFactory,
-        protected RawFactory $resultRawFactory,
-        protected Data $helper,
-        private Logger $logger,
-        private ConektaLogger $conektaLogger,
-        private WebhookRepository $webhookRepository
+        JsonFactory $resultJsonFactory,
+        RawFactory $resultRawFactory,
+        Data $helper,
+        Logger $logger,
+        ConektaLogger $conektaLogger,
+        WebhookRepository $webhookRepository
     ) {
+        $this->resultJsonFactory = $resultJsonFactory;
+        $this->resultRawFactory = $resultRawFactory;
+        $this->helper = $helper;
+        $this->logger = $logger;
+        $this->conektaLogger = $conektaLogger;
+        $this->webhookRepository = $webhookRepository;
         parent::__construct($context);
     }
 

--- a/Gateway/Command/GatewayCommand.php
+++ b/Gateway/Command/GatewayCommand.php
@@ -20,6 +20,13 @@ use Magento\Payment\Gateway\Validator\ValidatorInterface;
  */
 class GatewayCommand implements CommandInterface
 {
+    private ?ValidatorInterface $validator = null;
+    private ?HandlerInterface $handler = null;
+    private ConektaLogger $conektaLogger;
+    private ClientInterface $client;
+    private TransferFactoryInterface $transferFactory;
+    private BuilderInterface $requestBuilder;
+
     /**
      * GatewayCommand construct
      *
@@ -31,13 +38,19 @@ class GatewayCommand implements CommandInterface
      * @param ValidatorInterface|null $validator
      */
     public function __construct(
-        private BuilderInterface         $requestBuilder,
-        private TransferFactoryInterface $transferFactory,
-        private ClientInterface          $client,
-        private ConektaLogger            $conektaLogger,
-        private ?HandlerInterface        $handler = null,
-        private ?ValidatorInterface      $validator = null
+        BuilderInterface         $requestBuilder,
+        TransferFactoryInterface $transferFactory,
+        ClientInterface          $client,
+        ConektaLogger            $conektaLogger,
+        ?HandlerInterface        $handler = null,
+        ?ValidatorInterface      $validator = null
     ) {
+        $this->requestBuilder = $requestBuilder;
+        $this->transferFactory = $transferFactory;
+        $this->client = $client;
+        $this->conektaLogger = $conektaLogger;
+        $this->handler = $handler;
+        $this->validator = $validator;
         $this->conektaLogger->info('Command GatewayCommand :: __construct');
     }
 
@@ -77,10 +90,12 @@ class GatewayCommand implements CommandInterface
             }
         }
 
-        $this->handler?->handle(
-            $commandSubject,
-            $response
-        );
+        if ($this->handler) {
+            $this->handler->handle(
+                $commandSubject,
+                $response
+            );
+        }
     }
 
     /**

--- a/Gateway/Config/CreditCard/PaymentActionValueHandler.php
+++ b/Gateway/Config/CreditCard/PaymentActionValueHandler.php
@@ -10,14 +10,17 @@ use Magento\Payment\Gateway\Config\ValueHandlerInterface;
  */
 class PaymentActionValueHandler implements ValueHandlerInterface
 {
+    protected ConektaHelper $_conektaHelper;
+
     /**
      * PaymentActionValueHandler construct
      *
      * @param ConektaHelper $_conektaHelper
      */
     public function __construct(
-        protected ConektaHelper $_conektaHelper
+        ConektaHelper $_conektaHelper
     ) {
+        $this->_conektaHelper = $_conektaHelper;
     }
 
     /**

--- a/Gateway/Config/EmbedForm/ActiveValueHandler.php
+++ b/Gateway/Config/EmbedForm/ActiveValueHandler.php
@@ -7,12 +7,15 @@ use Magento\Payment\Gateway\Config\ValueHandlerInterface;
 
 class ActiveValueHandler implements ValueHandlerInterface
 {
+    protected ConektaHelper $_conektaHelper;
+
     /**
      * @param ConektaHelper $_conektaHelper
      */
     public function __construct(
-        protected ConektaHelper $_conektaHelper
+        ConektaHelper $_conektaHelper
     ) {
+        $this->_conektaHelper = $_conektaHelper;
     }
 
     /**

--- a/Gateway/Config/EmbedForm/PaymentActionValueHandler.php
+++ b/Gateway/Config/EmbedForm/PaymentActionValueHandler.php
@@ -7,12 +7,15 @@ use Magento\Payment\Gateway\Config\ValueHandlerInterface;
 
 class PaymentActionValueHandler implements ValueHandlerInterface
 {
+    protected ConektaHelper $_conektaHelper;
+
     /**
      * @param ConektaHelper $_conektaHelper
      */
     public function __construct(
-        protected ConektaHelper $_conektaHelper
+        ConektaHelper $_conektaHelper
     ) {
+        $this->_conektaHelper = $_conektaHelper;
     }
 
     /**

--- a/Gateway/Config/Oxxo/PaymentActionValueHandler.php
+++ b/Gateway/Config/Oxxo/PaymentActionValueHandler.php
@@ -7,12 +7,15 @@ use Magento\Payment\Gateway\Config\ValueHandlerInterface;
 
 class PaymentActionValueHandler implements ValueHandlerInterface
 {
+    protected ConektaHelper $_conektaHelper;
+
     /**
      * @param ConektaHelper $_conektaHelper
      */
     public function __construct(
-        protected ConektaHelper $_conektaHelper
+        ConektaHelper $_conektaHelper
     ) {
+        $this->_conektaHelper = $_conektaHelper;
     }
 
     /**

--- a/Gateway/Config/Spei/PaymentActionValueHandler.php
+++ b/Gateway/Config/Spei/PaymentActionValueHandler.php
@@ -7,12 +7,15 @@ use Magento\Payment\Gateway\Config\ValueHandlerInterface;
 
 class PaymentActionValueHandler implements ValueHandlerInterface
 {
+    protected ConektaHelper $_conektaHelper;
+
     /**
      * @param ConektaHelper $_conektaHelper
      */
     public function __construct(
-        protected ConektaHelper $_conektaHelper
+        ConektaHelper $_conektaHelper
     ) {
+        $this->_conektaHelper = $_conektaHelper;
     }
 
     /**

--- a/Gateway/Http/Client/CreditCard/TransactionCapture.php
+++ b/Gateway/Http/Client/CreditCard/TransactionCapture.php
@@ -17,6 +17,9 @@ class TransactionCapture implements ClientInterface
 {
     public const SUCCESS = 1;
     public const FAILURE = 0;
+    protected ConektaSalesOrderFactory $conektaSalesOrderFactory;
+    protected HttpUtil $_httpUtil;
+    protected ConektaHelper $_conektaHelper;
 
     /**
      * @var array
@@ -25,6 +28,9 @@ class TransactionCapture implements ClientInterface
         self::SUCCESS,
         self::FAILURE
     ];
+    private ConektaOrder $conektaOrder;
+    private ConektaLogger $conektaLogger;
+    private Logger $logger;
 
     /**
      * @param Logger $logger
@@ -36,13 +42,19 @@ class TransactionCapture implements ClientInterface
      * @throws Exception
      */
     public function __construct(
-        private Logger $logger,
-        protected ConektaHelper $_conektaHelper,
-        private ConektaLogger $conektaLogger,
-        private ConektaOrder $conektaOrder,
-        protected HttpUtil $_httpUtil,
-        protected ConektaSalesOrderFactory $conektaSalesOrderFactory
+        Logger $logger,
+        ConektaHelper $_conektaHelper,
+        ConektaLogger $conektaLogger,
+        ConektaOrder $conektaOrder,
+        HttpUtil $_httpUtil,
+        ConektaSalesOrderFactory $conektaSalesOrderFactory
     ) {
+        $this->logger = $logger;
+        $this->_conektaHelper = $_conektaHelper;
+        $this->conektaLogger = $conektaLogger;
+        $this->conektaOrder = $conektaOrder;
+        $this->_httpUtil = $_httpUtil;
+        $this->conektaSalesOrderFactory = $conektaSalesOrderFactory;
         $config = [
             'locale' => 'es'
         ];

--- a/Gateway/Http/Client/CreditCard/TransactionRefund.php
+++ b/Gateway/Http/Client/CreditCard/TransactionRefund.php
@@ -14,6 +14,14 @@ use Magento\Payment\Model\Method\Logger;
 
 class TransactionRefund implements ClientInterface
 {
+    protected HttpUtil $_httpUtil;
+    protected ConektaHelper $_conektaHelper;
+    private Logger $logger;
+    private EncryptorInterface $encryptor;
+    private Context $context;
+    private ConektaOrder $conektaOrder;
+    private ConektaLogger $conektaLogger;
+
     /**
      * @param ConektaHelper $_conektaHelper
      * @param ConektaLogger $conektaLogger
@@ -26,15 +34,22 @@ class TransactionRefund implements ClientInterface
      * @throws Exception
      */
     public function __construct(
-        protected ConektaHelper $_conektaHelper,
-        private ConektaLogger $conektaLogger,
-        private ConektaOrder $conektaOrder,
-        protected HttpUtil $_httpUtil,
-        private Context $context,
-        private EncryptorInterface $encryptor,
-        private Logger $logger,
+        ConektaHelper $_conektaHelper,
+        ConektaLogger $conektaLogger,
+        ConektaOrder $conektaOrder,
+        HttpUtil $_httpUtil,
+        Context $context,
+        EncryptorInterface $encryptor,
+        Logger $logger,
         array $data = []
     ) {
+        $this->_conektaHelper = $_conektaHelper;
+        $this->conektaLogger = $conektaLogger;
+        $this->conektaOrder = $conektaOrder;
+        $this->_httpUtil = $_httpUtil;
+        $this->context = $context;
+        $this->encryptor = $encryptor;
+        $this->logger = $logger;
         $config = [
             'locale' => 'es'
         ];

--- a/Gateway/Http/Client/EmbedForm/TransactionAuthorize.php
+++ b/Gateway/Http/Client/EmbedForm/TransactionAuthorize.php
@@ -17,6 +17,10 @@ class TransactionAuthorize implements ClientInterface
 {
     public const SUCCESS = 1;
     public const FAILURE = 0;
+    protected ConektaSalesOrderFactory $conektaSalesOrderFactory;
+    protected HttpUtil $httpUtil;
+    protected ConektaOrder $conektaOrder;
+    protected ConektaHelper $conektaHelper;
 
     /**
      * @var array
@@ -25,6 +29,8 @@ class TransactionAuthorize implements ClientInterface
         self::SUCCESS,
         self::FAILURE
     ];
+    private ConektaLogger $conektaLogger;
+    private Logger $logger;
 
     /**
      * @param Logger $logger
@@ -36,13 +42,19 @@ class TransactionAuthorize implements ClientInterface
      * @throws \Magento\Framework\Validator\Exception
      */
     public function __construct(
-        private Logger $logger,
-        protected ConektaHelper $conektaHelper,
-        private ConektaLogger $conektaLogger,
-        protected ConektaOrder $conektaOrder,
-        protected HttpUtil $httpUtil,
-        protected ConektaSalesOrderFactory $conektaSalesOrderFactory
+        Logger $logger,
+        ConektaHelper $conektaHelper,
+        ConektaLogger $conektaLogger,
+        ConektaOrder $conektaOrder,
+        HttpUtil $httpUtil,
+        ConektaSalesOrderFactory $conektaSalesOrderFactory
     ) {
+        $this->logger = $logger;
+        $this->conektaHelper = $conektaHelper;
+        $this->conektaLogger = $conektaLogger;
+        $this->conektaOrder = $conektaOrder;
+        $this->httpUtil = $httpUtil;
+        $this->conektaSalesOrderFactory = $conektaSalesOrderFactory;
         $config = [
             'locale' => 'es'
         ];

--- a/Gateway/Http/Client/Oxxo/TransactionAuthorize.php
+++ b/Gateway/Http/Client/Oxxo/TransactionAuthorize.php
@@ -17,6 +17,9 @@ class TransactionAuthorize implements ClientInterface
 {
     public const SUCCESS = 1;
     public const FAILURE = 0;
+    protected ConektaSalesOrderFactory $conektaSalesOrderFactory;
+    protected HttpUtil $httpUtil;
+    protected ConektaHelper $conektaHelper;
 
     /**
      * @var array
@@ -25,6 +28,9 @@ class TransactionAuthorize implements ClientInterface
         self::SUCCESS,
         self::FAILURE
     ];
+    private ConektaOrder $conektaOrder;
+    private ConektaLogger $conektaLogger;
+    private Logger $logger;
 
     /**
      * @param Logger $logger
@@ -36,13 +42,19 @@ class TransactionAuthorize implements ClientInterface
      * @throws Exception
      */
     public function __construct(
-        private Logger $logger,
-        protected ConektaHelper $conektaHelper,
-        private ConektaLogger $conektaLogger,
-        private ConektaOrder $conektaOrder,
-        protected HttpUtil $httpUtil,
-        protected ConektaSalesOrderFactory $conektaSalesOrderFactory
+        Logger $logger,
+        ConektaHelper $conektaHelper,
+        ConektaLogger $conektaLogger,
+        ConektaOrder $conektaOrder,
+        HttpUtil $httpUtil,
+        ConektaSalesOrderFactory $conektaSalesOrderFactory
     ) {
+        $this->logger = $logger;
+        $this->conektaHelper = $conektaHelper;
+        $this->conektaLogger = $conektaLogger;
+        $this->conektaOrder = $conektaOrder;
+        $this->httpUtil = $httpUtil;
+        $this->conektaSalesOrderFactory = $conektaSalesOrderFactory;
         $config = [
             'locale' => 'es'
         ];

--- a/Gateway/Http/Client/Spei/TransactionAuthorize.php
+++ b/Gateway/Http/Client/Spei/TransactionAuthorize.php
@@ -17,6 +17,9 @@ class TransactionAuthorize implements ClientInterface
 {
     public const SUCCESS = 1;
     public const FAILURE = 0;
+    protected ConektaSalesOrderFactory $conektaSalesOrderFactory;
+    protected HttpUtil $httpUtil;
+    protected ConektaHelper $conektaHelper;
 
     /**
      * @var array
@@ -25,6 +28,9 @@ class TransactionAuthorize implements ClientInterface
         self::SUCCESS,
         self::FAILURE
     ];
+    private ConektaOrder $conektaOrder;
+    private ConektaLogger $conektaLogger;
+    private Logger $logger;
 
     /**
      * @param Logger $logger
@@ -36,13 +42,19 @@ class TransactionAuthorize implements ClientInterface
      * @throws Exception
      */
     public function __construct(
-        private Logger                     $logger,
-        protected ConektaHelper            $conektaHelper,
-        private ConektaLogger              $conektaLogger,
-        private ConektaOrder               $conektaOrder,
-        protected HttpUtil                 $httpUtil,
-        protected ConektaSalesOrderFactory $conektaSalesOrderFactory
+        Logger                     $logger,
+        ConektaHelper            $conektaHelper,
+        ConektaLogger              $conektaLogger,
+        ConektaOrder               $conektaOrder,
+        HttpUtil                 $httpUtil,
+        ConektaSalesOrderFactory $conektaSalesOrderFactory
     ) {
+        $this->logger = $logger;
+        $this->conektaHelper = $conektaHelper;
+        $this->conektaLogger = $conektaLogger;
+        $this->conektaOrder = $conektaOrder;
+        $this->httpUtil = $httpUtil;
+        $this->conektaSalesOrderFactory = $conektaSalesOrderFactory;
         $config = [
             'locale' => 'es'
         ];

--- a/Gateway/Http/TransferFactory.php
+++ b/Gateway/Http/TransferFactory.php
@@ -7,14 +7,19 @@ use Magento\Payment\Gateway\Http\{TransferBuilder, TransferFactoryInterface, Tra
 
 class TransferFactory implements TransferFactoryInterface
 {
+    private ConektaLogger $conektaLogger;
+    private TransferBuilder $transferBuilder;
+
     /**
      * @param TransferBuilder $transferBuilder
      * @param ConektaLogger $conektaLogger
      */
     public function __construct(
-        private TransferBuilder $transferBuilder,
-        private ConektaLogger $conektaLogger
+        TransferBuilder $transferBuilder,
+        ConektaLogger $conektaLogger
     ) {
+        $this->transferBuilder = $transferBuilder;
+        $this->conektaLogger = $conektaLogger;
         $this->conektaLogger->info('HTTP TransferFactory :: __construct');
     }
 

--- a/Gateway/Http/Util/HttpUtil.php
+++ b/Gateway/Http/Util/HttpUtil.php
@@ -8,12 +8,15 @@ use Magento\Framework\Validator\Exception;
 
 class HttpUtil
 {
+    protected ConektaHelper $conektaHelper;
+
     /**
      * @param ConektaHelper $conektaHelper
      */
     public function __construct(
-        protected ConektaHelper $conektaHelper
+        ConektaHelper $conektaHelper
     ) {
+        $this->conektaHelper = $conektaHelper;
     }
 
     /**

--- a/Gateway/Request/CreditCard/CaptureRequest.php
+++ b/Gateway/Request/CreditCard/CaptureRequest.php
@@ -11,6 +11,11 @@ use Magento\Payment\Gateway\Helper\SubjectReader;
 
 class CaptureRequest implements CaptureRequestInterface
 {
+    protected ConektaHelper $conektaHelper;
+    private ConektaLogger $conektaLogger;
+    private SubjectReader $subjectReader;
+    private ConfigInterface $config;
+
     /**
      * @param ConfigInterface $config
      * @param SubjectReader $subjectReader
@@ -18,11 +23,15 @@ class CaptureRequest implements CaptureRequestInterface
      * @param ConektaLogger $conektaLogger
      */
     public function __construct(
-        private ConfigInterface $config,
-        private SubjectReader $subjectReader,
-        protected ConektaHelper $conektaHelper,
-        private ConektaLogger $conektaLogger
+        ConfigInterface $config,
+        SubjectReader $subjectReader,
+        ConektaHelper $conektaHelper,
+        ConektaLogger $conektaLogger
     ) {
+        $this->config = $config;
+        $this->subjectReader = $subjectReader;
+        $this->conektaHelper = $conektaHelper;
+        $this->conektaLogger = $conektaLogger;
         $this->conektaLogger->info('Request CaptureRequest :: __construct');
     }
 

--- a/Gateway/Request/CreditCard/RefundBuilder.php
+++ b/Gateway/Request/CreditCard/RefundBuilder.php
@@ -9,16 +9,23 @@ use Magento\Payment\Gateway\Request\BuilderInterface;
 
 class RefundBuilder implements BuilderInterface
 {
+    protected ConektaHelper $conektaHelper;
+    private ConektaLogger $conektaLogger;
+    private SubjectReader $subjectReader;
+
     /**
      * @param SubjectReader $subjectReader
      * @param ConektaHelper $conektaHelper
      * @param ConektaLogger $conektaLogger
      */
     public function __construct(
-        private SubjectReader $subjectReader,
-        protected ConektaHelper $conektaHelper,
-        private ConektaLogger $conektaLogger
+        SubjectReader $subjectReader,
+        ConektaHelper $conektaHelper,
+        ConektaLogger $conektaLogger
     ) {
+        $this->subjectReader = $subjectReader;
+        $this->conektaHelper = $conektaHelper;
+        $this->conektaLogger = $conektaLogger;
         $this->conektaLogger->info('Request RefundBuilder :: __construct');
     }
 

--- a/Gateway/Request/CustomerInfoBuilder.php
+++ b/Gateway/Request/CustomerInfoBuilder.php
@@ -9,14 +9,19 @@ use Magento\Payment\Gateway\Request\BuilderInterface;
 
 class CustomerInfoBuilder implements BuilderInterface
 {
+    private ConektaLogger $conektaLogger;
+    private Product $product;
+
     /**
      * @param Product $product
      * @param ConektaLogger $conektaLogger
      */
     public function __construct(
-        private Product $product,
-        private ConektaLogger $conektaLogger
+        Product $product,
+        ConektaLogger $conektaLogger
     ) {
+        $this->product = $product;
+        $this->conektaLogger = $conektaLogger;
         $this->conektaLogger->info('Request LineItemsBuilder :: __construct');
     }
 

--- a/Gateway/Request/DiscountLinesBuilder.php
+++ b/Gateway/Request/DiscountLinesBuilder.php
@@ -11,6 +11,11 @@ use Magento\Quote\Api\CartRepositoryInterface;
 
 class DiscountLinesBuilder implements BuilderInterface
 {
+    protected CartRepositoryInterface $cartRepository;
+    private ConektaHelper $conektaHelper;
+    private SubjectReader $subjectReader;
+    private ConektaLogger $conektaLogger;
+
     /**
      * @param ConektaLogger $conektaLogger
      * @param SubjectReader $subjectReader
@@ -18,11 +23,15 @@ class DiscountLinesBuilder implements BuilderInterface
      * @param ConektaHelper $conektaHelper
      */
     public function __construct(
-        private ConektaLogger             $conektaLogger,
-        private SubjectReader             $subjectReader,
-        protected CartRepositoryInterface $cartRepository,
-        private ConektaHelper             $conektaHelper
+        ConektaLogger             $conektaLogger,
+        SubjectReader             $subjectReader,
+        CartRepositoryInterface $cartRepository,
+        ConektaHelper             $conektaHelper
     ) {
+        $this->conektaLogger = $conektaLogger;
+        $this->subjectReader = $subjectReader;
+        $this->cartRepository = $cartRepository;
+        $this->conektaHelper = $conektaHelper;
         $this->conektaLogger->info('Request DiscountLinesBuilder :: __construct');
     }
 

--- a/Gateway/Request/EmbedForm/CaptureRequest.php
+++ b/Gateway/Request/EmbedForm/CaptureRequest.php
@@ -15,6 +15,15 @@ use Magento\Payment\Gateway\Helper\SubjectReader;
 
 class CaptureRequest implements CaptureRequestInterface
 {
+    protected ConektaCustomer $conektaCustomer;
+    protected CustomerRepositoryInterface $customerRepository;
+    protected CustomerSession $customerSession;
+    protected Config $conektaConfig;
+    protected ConektaLogger $conektaLogger;
+    protected ConektaHelper $conektaHelper;
+    protected SubjectReader $subjectReader;
+    protected ConfigInterface $config;
+
     /**
      * CaptureRequest constructor.
      * @param ConfigInterface $config
@@ -27,15 +36,23 @@ class CaptureRequest implements CaptureRequestInterface
      * @param ConektaCustomer $conektaCustomer
      */
     public function __construct(
-        protected ConfigInterface $config,
-        protected SubjectReader $subjectReader,
-        protected ConektaHelper $conektaHelper,
-        protected ConektaLogger $conektaLogger,
-        protected Config $conektaConfig,
-        protected CustomerSession $customerSession,
-        protected CustomerRepositoryInterface $customerRepository,
-        protected ConektaCustomer $conektaCustomer
+        ConfigInterface $config,
+        SubjectReader $subjectReader,
+        ConektaHelper $conektaHelper,
+        ConektaLogger $conektaLogger,
+        Config $conektaConfig,
+        CustomerSession $customerSession,
+        CustomerRepositoryInterface $customerRepository,
+        ConektaCustomer $conektaCustomer
     ) {
+        $this->config = $config;
+        $this->subjectReader = $subjectReader;
+        $this->conektaHelper = $conektaHelper;
+        $this->conektaLogger = $conektaLogger;
+        $this->conektaConfig = $conektaConfig;
+        $this->customerSession = $customerSession;
+        $this->customerRepository = $customerRepository;
+        $this->conektaCustomer = $conektaCustomer;
         $this->conektaLogger->info('EMBED Request CaptureRequest :: __construct');
     }
 

--- a/Gateway/Request/LineItemsBuilder.php
+++ b/Gateway/Request/LineItemsBuilder.php
@@ -11,6 +11,11 @@ use Magento\Payment\Gateway\Request\BuilderInterface;
 
 class LineItemsBuilder implements BuilderInterface
 {
+    protected ConektaLogger $conektaLogger;
+    protected ConektaHelper $conektaHelper;
+    private Escaper $escaper;
+    private Product $product;
+
     /**
      * @param Product $product
      * @param Escaper $escaper
@@ -18,11 +23,15 @@ class LineItemsBuilder implements BuilderInterface
      * @param ConektaLogger $conektaLogger
      */
     public function __construct(
-        private Product $product,
-        private Escaper $escaper,
-        protected ConektaHelper $conektaHelper,
-        protected ConektaLogger $conektaLogger
+        Product $product,
+        Escaper $escaper,
+        ConektaHelper $conektaHelper,
+        ConektaLogger $conektaLogger
     ) {
+        $this->product = $product;
+        $this->escaper = $escaper;
+        $this->conektaHelper = $conektaHelper;
+        $this->conektaLogger = $conektaLogger;
         $this->conektaLogger->info('Request LineItemsBuilder :: __construct');
     }
 

--- a/Gateway/Request/MetadataBuilder.php
+++ b/Gateway/Request/MetadataBuilder.php
@@ -11,6 +11,11 @@ use Magento\Payment\Gateway\Request\BuilderInterface;
 
 class MetadataBuilder implements BuilderInterface
 {
+    protected ConektaHelper $conektaHelper;
+    protected Escaper $_escaper;
+    private SubjectReader $subjectReader;
+    private ConektaLogger $conektaLogger;
+
     /**
      * @param Escaper $_escaper
      * @param ConektaHelper $conektaHelper
@@ -18,11 +23,15 @@ class MetadataBuilder implements BuilderInterface
      * @param SubjectReader $subjectReader
      */
     public function __construct(
-        protected Escaper $_escaper,
-        protected ConektaHelper $conektaHelper,
-        private ConektaLogger $conektaLogger,
-        private SubjectReader $subjectReader
+        Escaper $_escaper,
+        ConektaHelper $conektaHelper,
+        ConektaLogger $conektaLogger,
+        SubjectReader $subjectReader
     ) {
+        $this->_escaper = $_escaper;
+        $this->conektaHelper = $conektaHelper;
+        $this->conektaLogger = $conektaLogger;
+        $this->subjectReader = $subjectReader;
         $this->conektaLogger->info('Request MetadataBuilder :: __construct');
     }
 

--- a/Gateway/Request/Oxxo/AuthorizeRequest.php
+++ b/Gateway/Request/Oxxo/AuthorizeRequest.php
@@ -10,6 +10,11 @@ use Magento\Payment\Gateway\Helper\SubjectReader;
 
 class AuthorizeRequest implements AutorizeRequestInterface
 {
+    protected ConektaHelper $conektaHelper;
+    private ConektaLogger $conektaLogger;
+    private SubjectReader $subjectReader;
+    private ConfigInterface $config;
+
     /**
      * @param ConfigInterface $config
      * @param SubjectReader $subjectReader
@@ -17,11 +22,15 @@ class AuthorizeRequest implements AutorizeRequestInterface
      * @param ConektaLogger $conektaLogger
      */
     public function __construct(
-        private ConfigInterface $config,
-        private SubjectReader   $subjectReader,
-        protected ConektaHelper $conektaHelper,
-        private ConektaLogger   $conektaLogger
+        ConfigInterface $config,
+        SubjectReader   $subjectReader,
+        ConektaHelper $conektaHelper,
+        ConektaLogger   $conektaLogger
     ) {
+        $this->config = $config;
+        $this->subjectReader = $subjectReader;
+        $this->conektaHelper = $conektaHelper;
+        $this->conektaLogger = $conektaLogger;
         $this->conektaLogger->info('Request Oxxo AuthorizeRequest :: __construct');
     }
 

--- a/Gateway/Request/ShippingContactBuilder.php
+++ b/Gateway/Request/ShippingContactBuilder.php
@@ -10,11 +10,18 @@ use Magento\Payment\Gateway\Request\BuilderInterface;
 
 class ShippingContactBuilder implements BuilderInterface
 {
+    private ConektaHelper $conektaHelper;
+    private ConektaLogger $conektaLogger;
+    private SubjectReader $subjectReader;
+
     public function __construct(
-        private SubjectReader $subjectReader,
-        private ConektaLogger $conektaLogger,
-        private ConektaHelper $conektaHelper
+        SubjectReader $subjectReader,
+        ConektaLogger $conektaLogger,
+        ConektaHelper $conektaHelper
     ) {
+        $this->subjectReader = $subjectReader;
+        $this->conektaLogger = $conektaLogger;
+        $this->conektaHelper = $conektaHelper;
         $this->conektaLogger->info('Request ShippingContactBuilder :: __construct');
     }
 

--- a/Gateway/Request/ShippingLinesBuilder.php
+++ b/Gateway/Request/ShippingLinesBuilder.php
@@ -10,16 +10,23 @@ use Magento\Payment\Gateway\Request\BuilderInterface;
 
 class ShippingLinesBuilder implements BuilderInterface
 {
+    private ConektaHelper $conektaHelper;
+    private ConektaLogger $conektaLogger;
+    private SubjectReader $subjectReader;
+
     /**
      * @param SubjectReader $subjectReader
      * @param ConektaLogger $conektaLogger
      * @param ConektaHelper $conektaHelper
      */
     public function __construct(
-        private SubjectReader $subjectReader,
-        private ConektaLogger $conektaLogger,
-        private ConektaHelper $conektaHelper
+        SubjectReader $subjectReader,
+        ConektaLogger $conektaLogger,
+        ConektaHelper $conektaHelper
     ) {
+        $this->subjectReader = $subjectReader;
+        $this->conektaLogger = $conektaLogger;
+        $this->conektaHelper = $conektaHelper;
         $this->conektaLogger->info('Request ShippingLinesBuilder :: __construct');
     }
 

--- a/Gateway/Request/Spei/AuthorizeRequest.php
+++ b/Gateway/Request/Spei/AuthorizeRequest.php
@@ -10,6 +10,11 @@ use Magento\Payment\Gateway\Helper\SubjectReader;
 
 class AuthorizeRequest implements AutorizeRequestInterface
 {
+    protected ConektaHelper $conektaHelper;
+    private ConektaLogger $conektaLogger;
+    private SubjectReader $subjectReader;
+    private ConfigInterface $config;
+
     /**
      * @param ConfigInterface $config
      * @param SubjectReader $subjectReader
@@ -17,11 +22,15 @@ class AuthorizeRequest implements AutorizeRequestInterface
      * @param ConektaLogger $conektaLogger
      */
     public function __construct(
-        private ConfigInterface $config,
-        private SubjectReader $subjectReader,
-        protected ConektaHelper $conektaHelper,
-        private ConektaLogger $conektaLogger
+        ConfigInterface $config,
+        SubjectReader $subjectReader,
+        ConektaHelper $conektaHelper,
+        ConektaLogger $conektaLogger
     ) {
+        $this->config = $config;
+        $this->subjectReader = $subjectReader;
+        $this->conektaHelper = $conektaHelper;
+        $this->conektaLogger = $conektaLogger;
         $this->conektaLogger->info('Request Spei AuthorizeRequest :: __construct');
     }
 

--- a/Gateway/Request/TaxLinesBuilder.php
+++ b/Gateway/Request/TaxLinesBuilder.php
@@ -11,12 +11,21 @@ use Magento\Tax\Model\ClassModel;
 
 class TaxLinesBuilder implements BuilderInterface
 {
+    private ConektaHelper $conektaHelper;
+    private ConektaLogger $conektaLogger;
+    private ClassModel $taxClass;
+    private Product $product;
+
     public function __construct(
-        private Product $product,
-        private ClassModel $taxClass,
-        private ConektaLogger $conektaLogger,
-        private ConektaHelper $conektaHelper
+        Product $product,
+        ClassModel $taxClass,
+        ConektaLogger $conektaLogger,
+        ConektaHelper $conektaHelper
     ) {
+        $this->product = $product;
+        $this->taxClass = $taxClass;
+        $this->conektaLogger = $conektaLogger;
+        $this->conektaHelper = $conektaHelper;
         $this->conektaLogger->info('Request TaxLinesBuilder :: __construct');
     }
 

--- a/Gateway/Response/CreditCard/FraudHandler.php
+++ b/Gateway/Response/CreditCard/FraudHandler.php
@@ -10,12 +10,14 @@ use Magento\Sales\Model\Order\Payment;
 class FraudHandler implements HandlerInterface
 {
     public const FRAUD_MSG_LIST = 'FRAUD_MSG_LIST';
+    private ConektaLogger $conektaLogger;
 
     /**
      * @param ConektaLogger $conektaLogger
      */
-    public function __construct(private ConektaLogger $conektaLogger)
+    public function __construct(ConektaLogger $conektaLogger)
     {
+        $this->conektaLogger = $conektaLogger;
         $this->conektaLogger->info('Response FraudHandler :: __construct');
     }
 

--- a/Gateway/Response/CreditCard/RefundHandler.php
+++ b/Gateway/Response/CreditCard/RefundHandler.php
@@ -10,16 +10,23 @@ use Magento\Sales\Api\Data\TransactionInterface;
 
 class RefundHandler implements HandlerInterface
 {
+    protected ConektaHelper $conektaHelper;
+    private ConektaLogger $conektaLogger;
+    private SubjectReader $subjectReader;
+
     /**
      * @param SubjectReader $subjectReader
      * @param ConektaHelper $conektaHelper
      * @param ConektaLogger $conektaLogger
      */
     public function __construct(
-        private SubjectReader $subjectReader,
-        protected ConektaHelper $conektaHelper,
-        private ConektaLogger $conektaLogger
+        SubjectReader $subjectReader,
+        ConektaHelper $conektaHelper,
+        ConektaLogger $conektaLogger
     ) {
+        $this->subjectReader = $subjectReader;
+        $this->conektaHelper = $conektaHelper;
+        $this->conektaLogger = $conektaLogger;
         $this->conektaLogger->info('Response RefundHandler :: __construct');
     }
 

--- a/Gateway/Response/CreditCard/TxnIdHandler.php
+++ b/Gateway/Response/CreditCard/TxnIdHandler.php
@@ -10,6 +10,8 @@ class TxnIdHandler implements HandlerInterface
 {
     public const TXN_ID = 'TXN_ID';
     public const ORD_ID = 'ORD_ID';
+    private SubjectReader $subjectReader;
+    private ConektaLogger $conektaLogger;
 
     /**
      * TxnIdHandler constructor.
@@ -17,9 +19,11 @@ class TxnIdHandler implements HandlerInterface
      * @param SubjectReader $subjectReader
      */
     public function __construct(
-        private ConektaLogger $conektaLogger,
-        private SubjectReader $subjectReader
+        ConektaLogger $conektaLogger,
+        SubjectReader $subjectReader
     ) {
+        $this->conektaLogger = $conektaLogger;
+        $this->subjectReader = $subjectReader;
         $this->conektaLogger->info('Response TxnIdHandler :: __construct');
     }
 

--- a/Gateway/Response/EmbedForm/TxnIdHandler.php
+++ b/Gateway/Response/EmbedForm/TxnIdHandler.php
@@ -11,6 +11,8 @@ class TxnIdHandler implements HandlerInterface
 {
     public const TXN_ID = 'TXN_ID';
     public const ORD_ID = 'ORD_ID';
+    private SubjectReader $subjectReader;
+    private ConektaLogger $conektaLogger;
 
     /**
      * TxnIdHandler constructor.
@@ -19,9 +21,11 @@ class TxnIdHandler implements HandlerInterface
      * @param SubjectReader $subjectReader
      */
     public function __construct(
-        private ConektaLogger $conektaLogger,
-        private SubjectReader $subjectReader
+        ConektaLogger $conektaLogger,
+        SubjectReader $subjectReader
     ) {
+        $this->conektaLogger = $conektaLogger;
+        $this->subjectReader = $subjectReader;
         $this->conektaLogger->info('Response TxnIdHandler :: __construct');
     }
 

--- a/Gateway/Response/Oxxo/TxnIdHandler.php
+++ b/Gateway/Response/Oxxo/TxnIdHandler.php
@@ -10,6 +10,8 @@ class TxnIdHandler implements HandlerInterface
 {
     public const TXN_ID = 'TXN_ID';
     public const ORD_ID = 'ORD_ID';
+    private SubjectReader $subjectReader;
+    private ConektaLogger $conektaLogger;
 
     /**
      * TxnIdHandler constructor.
@@ -17,9 +19,11 @@ class TxnIdHandler implements HandlerInterface
      * @param SubjectReader $subjectReader
      */
     public function __construct(
-        private ConektaLogger $conektaLogger,
-        private SubjectReader $subjectReader
+        ConektaLogger $conektaLogger,
+        SubjectReader $subjectReader
     ) {
+        $this->conektaLogger = $conektaLogger;
+        $this->subjectReader = $subjectReader;
         $this->conektaLogger->info('Response Oxxo TxnIdHandler :: __construct');
     }
 

--- a/Gateway/Response/Spei/TxnIdHandler.php
+++ b/Gateway/Response/Spei/TxnIdHandler.php
@@ -10,6 +10,8 @@ class TxnIdHandler implements HandlerInterface
 {
     public const TXN_ID = 'TXN_ID';
     public const ORD_ID = 'ORD_ID';
+    private SubjectReader $subjectReader;
+    private ConektaLogger $conektaLogger;
 
     /**
      * TxnIdHandler constructor.
@@ -17,9 +19,11 @@ class TxnIdHandler implements HandlerInterface
      * @param SubjectReader $subjectReader
      */
     public function __construct(
-        private ConektaLogger $conektaLogger,
-        private SubjectReader $subjectReader
+        ConektaLogger $conektaLogger,
+        SubjectReader $subjectReader
     ) {
+        $this->conektaLogger = $conektaLogger;
+        $this->subjectReader = $subjectReader;
         $this->conektaLogger->info('Response Spei TxnIdHandler :: __construct');
     }
 

--- a/Gateway/Validator/CreditCard/RefundValidator.php
+++ b/Gateway/Validator/CreditCard/RefundValidator.php
@@ -10,6 +10,10 @@ use Magento\Payment\Gateway\Validator\{AbstractValidator, ResultInterface, Resul
 
 class RefundValidator extends AbstractValidator
 {
+    protected ConektaHelper $conektaHelper;
+    private ConektaLogger $conektaLogger;
+    private SubjectReader $subjectReader;
+
     /**
      * RefundValidator constructor.
      *
@@ -20,10 +24,13 @@ class RefundValidator extends AbstractValidator
      */
     public function __construct(
         ResultInterfaceFactory $resultFactory,
-        private SubjectReader $subjectReader,
-        protected ConektaHelper $conektaHelper,
-        private ConektaLogger $conektaLogger
+        SubjectReader $subjectReader,
+        ConektaHelper $conektaHelper,
+        ConektaLogger $conektaLogger
     ) {
+        $this->subjectReader = $subjectReader;
+        $this->conektaHelper = $conektaHelper;
+        $this->conektaLogger = $conektaLogger;
         $this->conektaLogger->info('Credit Card RefundValidator :: __construct');
         parent::__construct($resultFactory);
     }

--- a/Helper/ConektaOrder.php
+++ b/Helper/ConektaOrder.php
@@ -23,6 +23,16 @@ use Magento\Quote\Model\Quote;
 
 class ConektaOrder extends Util
 {
+    protected ConfigProvider $conektaConfigProvider;
+    protected CustomerRepositoryInterface $customerRepository;
+    protected Session $checkoutSession;
+    protected CustomerSession $customerSession;
+    protected ConektaOrderApi $conektaOrderApi;
+    protected ConektaCustomer $conektaCustomer;
+    protected ConektaLogger $conektaLogger;
+    protected Data $conektaHelper;
+    protected Context $context;
+
     /**
      * ConektaOrder constructor.
      * @param Context $context
@@ -36,16 +46,25 @@ class ConektaOrder extends Util
      * @param ConfigProvider $conektaConfigProvider
      */
     public function __construct(
-        protected Context $context,
-        protected ConektaHelper $conektaHelper,
-        protected ConektaLogger $conektaLogger,
-        protected ConektaCustomer $conektaCustomer,
-        protected ConektaOrderApi $conektaOrderApi,
-        protected CustomerSession $customerSession,
-        protected Session $checkoutSession,
-        protected CustomerRepositoryInterface $customerRepository,
-        protected ConfigProvider $conektaConfigProvider
+        Context $context,
+        ConektaHelper $conektaHelper,
+        ConektaLogger $conektaLogger,
+        ConektaCustomer $conektaCustomer,
+        ConektaOrderApi $conektaOrderApi,
+        CustomerSession $customerSession,
+        Session $checkoutSession,
+        CustomerRepositoryInterface $customerRepository,
+        ConfigProvider $conektaConfigProvider
     ) {
+        $this->context = $context;
+        $this->conektaHelper = $conektaHelper;
+        $this->conektaLogger = $conektaLogger;
+        $this->conektaCustomer = $conektaCustomer;
+        $this->conektaOrderApi = $conektaOrderApi;
+        $this->customerSession = $customerSession;
+        $this->checkoutSession = $checkoutSession;
+        $this->customerRepository = $customerRepository;
+        $this->conektaConfigProvider = $conektaConfigProvider;
         parent::__construct($context);
     }
 
@@ -96,9 +115,9 @@ class ConektaOrder extends Util
 
             if (strlen($customerRequest['phone']) < 10) {
                 $this->conektaLogger->info('Helper.CreateOrder phone validation error', $customerRequest);
-                throw new ConektaException(__('Télefono no válido. 
-                    El télefono debe tener al menos 10 carácteres. 
-                    Los caracteres especiales se desestimaran, solo se puede ingresar como 
+                throw new ConektaException(__('Télefono no válido.
+                    El télefono debe tener al menos 10 carácteres.
+                    Los caracteres especiales se desestimaran, solo se puede ingresar como
                     primer carácter especial: +'));
             }
 

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -18,6 +18,19 @@ use Magento\Store\Model\{ScopeInterface, StoreManagerInterface};
 
 class Data extends Util
 {
+    protected CartRepositoryInterface $cartRepository;
+    protected Customer $conektaCustomer;
+    protected ConektaLogger $conektaLogger;
+    protected ProductMetadataInterface $productMetadata;
+    protected EncryptorInterface $encryptor;
+    protected ModuleListInterface $moduleList;
+    protected Context $context;
+    private StoreManagerInterface $storeManager;
+    private Escaper $escaper;
+    private ProductRepository $productRepository;
+    private CustomerSession $customerSession;
+    private CheckoutSession $checkoutSession;
+
     /**
      * Data constructor.
      * @param Context $context
@@ -34,19 +47,31 @@ class Data extends Util
      * @param StoreManagerInterface $storeManager
      */
     public function __construct(
-        protected Context $context,
-        protected ModuleListInterface $moduleList,
-        protected EncryptorInterface $encryptor,
-        protected ProductMetadataInterface $productMetadata,
-        protected ConektaLogger $conektaLogger,
-        protected Customer $conektaCustomer,
-        private CheckoutSession $checkoutSession,
-        private CustomerSession $customerSession,
-        private ProductRepository $productRepository,
-        private Escaper $escaper,
-        protected CartRepositoryInterface $cartRepository,
-        private StoreManagerInterface $storeManager
+        Context $context,
+        ModuleListInterface $moduleList,
+        EncryptorInterface $encryptor,
+        ProductMetadataInterface $productMetadata,
+        ConektaLogger $conektaLogger,
+        Customer $conektaCustomer,
+        CheckoutSession $checkoutSession,
+        CustomerSession $customerSession,
+        ProductRepository $productRepository,
+        Escaper $escaper,
+        CartRepositoryInterface $cartRepository,
+        StoreManagerInterface $storeManager
     ) {
+        $this->context = $context;
+        $this->moduleList = $moduleList;
+        $this->encryptor = $encryptor;
+        $this->productMetadata = $productMetadata;
+        $this->conektaLogger = $conektaLogger;
+        $this->conektaCustomer = $conektaCustomer;
+        $this->checkoutSession = $checkoutSession;
+        $this->customerSession = $customerSession;
+        $this->productRepository = $productRepository;
+        $this->escaper = $escaper;
+        $this->cartRepository = $cartRepository;
+        $this->storeManager = $storeManager;
         parent::__construct($context);
     }
 

--- a/Model/ConektaQuoteRepository.php
+++ b/Model/ConektaQuoteRepository.php
@@ -9,14 +9,19 @@ use Magento\Framework\Exception\{AlreadyExistsException, NoSuchEntityException};
 
 class ConektaQuoteRepository implements ConektaQuoteRepositoryInterface
 {
+    private ConektaQuoteResource $conektaQuoteResource;
+    private ConektaQuoteFactory $conektaQuoteFactory;
+
     /**
      * @param ConektaQuoteFactory $conektaQuoteFactory
      * @param ConektaQuoteResource $conektaQuoteResource
      */
     public function __construct(
-        private ConektaQuoteFactory $conektaQuoteFactory,
-        private ConektaQuoteResource $conektaQuoteResource
+        ConektaQuoteFactory $conektaQuoteFactory,
+        ConektaQuoteResource $conektaQuoteResource
     ) {
+        $this->conektaQuoteFactory = $conektaQuoteFactory;
+        $this->conektaQuoteResource = $conektaQuoteResource;
     }
 
     /**

--- a/Model/Config.php
+++ b/Model/Config.php
@@ -11,6 +11,12 @@ use Magento\Framework\Validator\Exception;
 
 class Config
 {
+    protected Webhook $conektaWebhook;
+    protected Resolver $resolver;
+    protected ConektaHelper $conektaHelper;
+    protected EncryptorInterface $encryptor;
+    private ConektaLogger $conektaLogger;
+
     /**
      * @param EncryptorInterface $encryptor
      * @param ConektaHelper $conektaHelper
@@ -19,12 +25,17 @@ class Config
      * @param Webhook $conektaWebhook
      */
     public function __construct(
-        protected EncryptorInterface $encryptor,
-        protected ConektaHelper $conektaHelper,
-        protected Resolver $resolver,
-        private ConektaLogger $conektaLogger,
-        protected Webhook $conektaWebhook
+        EncryptorInterface $encryptor,
+        ConektaHelper $conektaHelper,
+        Resolver $resolver,
+        ConektaLogger $conektaLogger,
+        Webhook $conektaWebhook
     ) {
+        $this->encryptor = $encryptor;
+        $this->conektaHelper = $conektaHelper;
+        $this->resolver = $resolver;
+        $this->conektaLogger = $conektaLogger;
+        $this->conektaWebhook = $conektaWebhook;
     }
 
     /**

--- a/Model/EmbedFormRepository.php
+++ b/Model/EmbedFormRepository.php
@@ -11,6 +11,12 @@ use Magento\Framework\Exception\NoSuchEntityException;
 
 class EmbedFormRepository implements EmbedFormRepositoryInterface
 {
+    protected ConektaOrderApi $conektaOrderApi;
+    private ConektaQuoteRepositoryFactory $conektaQuoteRepositoryFactory;
+    private ConektaQuoteFactory $conektaQuoteFactory;
+    private ConektaQuoteInterface $conektaQuoteInterface;
+    private ConektaLogger $conektaLogger;
+
     /**
      * @param ConektaLogger $conektaLogger
      * @param ConektaQuoteInterface $conektaQuoteInterface
@@ -19,12 +25,17 @@ class EmbedFormRepository implements EmbedFormRepositoryInterface
      * @param ConektaQuoteRepositoryFactory $conektaQuoteRepositoryFactory
      */
     public function __construct(
-        private ConektaLogger $conektaLogger,
-        private ConektaQuoteInterface $conektaQuoteInterface,
-        protected ConektaOrderApi $conektaOrderApi,
-        private ConektaQuoteFactory $conektaQuoteFactory,
-        private ConektaQuoteRepositoryFactory $conektaQuoteRepositoryFactory
+        ConektaLogger $conektaLogger,
+        ConektaQuoteInterface $conektaQuoteInterface,
+        ConektaOrderApi $conektaOrderApi,
+        ConektaQuoteFactory $conektaQuoteFactory,
+        ConektaQuoteRepositoryFactory $conektaQuoteRepositoryFactory
     ) {
+        $this->conektaLogger = $conektaLogger;
+        $this->conektaQuoteInterface = $conektaQuoteInterface;
+        $this->conektaOrderApi = $conektaOrderApi;
+        $this->conektaQuoteFactory = $conektaQuoteFactory;
+        $this->conektaQuoteRepositoryFactory = $conektaQuoteRepositoryFactory;
     }
 
     /**

--- a/Model/System/Config/Source/MetadataOrder.php
+++ b/Model/System/Config/Source/MetadataOrder.php
@@ -7,12 +7,15 @@ use Magento\Sales\Model\ResourceModel\Order;
 
 class MetadataOrder implements ArrayInterface
 {
+    protected Order $orderResource;
+
     /**
      * @param Order $orderResource
      */
     public function __construct(
-        protected Order $orderResource
+        Order $orderResource
     ) {
+        $this->orderResource = $orderResource;
     }
 
     /**

--- a/Model/System/Config/Source/MetadataProduct.php
+++ b/Model/System/Config/Source/MetadataProduct.php
@@ -8,14 +8,19 @@ use Magento\Framework\Option\ArrayInterface;
 
 class MetadataProduct implements ArrayInterface
 {
+    protected AttributeRepositoryInterface $attributeRepository;
+    protected SearchCriteriaBuilder $searchCriteriaBuilder;
+
     /**
      * @param SearchCriteriaBuilder $searchCriteriaBuilder
      * @param AttributeRepositoryInterface $attributeRepository
      */
     public function __construct(
-        protected SearchCriteriaBuilder $searchCriteriaBuilder,
-        protected AttributeRepositoryInterface $attributeRepository
+        SearchCriteriaBuilder $searchCriteriaBuilder,
+        AttributeRepositoryInterface $attributeRepository
     ) {
+        $this->searchCriteriaBuilder = $searchCriteriaBuilder;
+        $this->attributeRepository = $attributeRepository;
     }
 
     /**

--- a/Model/Ui/ConfigProvider.php
+++ b/Model/Ui/ConfigProvider.php
@@ -9,15 +9,19 @@ use Magento\Framework\View\Asset\Repository as AssetRepository;
 class ConfigProvider implements ConfigProviderInterface
 {
     public const CODE = 'conekta_global';
+    protected ConektaHelper $conektaHelper;
+    private AssetRepository $assetRepository;
 
     /**
      * @param ConektaHelper $conektaHelper
      * @param AssetRepository $assetRepository
      */
     public function __construct(
-        protected ConektaHelper $conektaHelper,
-        private AssetRepository $assetRepository
+        ConektaHelper $conektaHelper,
+        AssetRepository $assetRepository
     ) {
+        $this->conektaHelper = $conektaHelper;
+        $this->assetRepository = $assetRepository;
     }
 
     /**

--- a/Model/Ui/CreditCard/ConfigProvider.php
+++ b/Model/Ui/CreditCard/ConfigProvider.php
@@ -13,6 +13,10 @@ use Magento\Quote\Model\Quote;
 class ConfigProvider implements ConfigProviderInterface
 {
     public const CODE = 'conekta_cc';
+    protected Session $checkoutSession;
+    protected ConektaHelper $conektaHelper;
+    protected CcConfig $ccCongig;
+    protected Repository $assetRepository;
 
     /**
      * @param Repository $assetRepository
@@ -21,11 +25,15 @@ class ConfigProvider implements ConfigProviderInterface
      * @param Session $checkoutSession
      */
     public function __construct(
-        protected Repository $assetRepository,
-        protected CcConfig $ccCongig,
-        protected ConektaHelper $conektaHelper,
-        protected Session $checkoutSession
+        Repository $assetRepository,
+        CcConfig $ccCongig,
+        ConektaHelper $conektaHelper,
+        Session $checkoutSession
     ) {
+        $this->assetRepository = $assetRepository;
+        $this->ccCongig = $ccCongig;
+        $this->conektaHelper = $conektaHelper;
+        $this->checkoutSession = $checkoutSession;
     }
 
     /**
@@ -182,7 +190,7 @@ class ConfigProvider implements ConfigProviderInterface
      * @throws LocalizedException
      * @throws NoSuchEntityException
      */
-    public function getQuote(): CartInterface|Quote
+    public function getQuote()
     {
         return $this->checkoutSession->getQuote();
     }

--- a/Model/Ui/EmbedForm/ConfigProvider.php
+++ b/Model/Ui/EmbedForm/ConfigProvider.php
@@ -23,6 +23,10 @@ class ConfigProvider implements ConfigProviderInterface
     public const PAYMENT_METHOD_CREDIT_CARD = 'credit';
     public const PAYMENT_METHOD_OXXO = 'oxxo';
     public const PAYMENT_METHOD_SPEI = 'spei';
+    protected ConektaHelper $conektaHelper;
+    protected Session $checkoutSession;
+    protected ConektaLogger $conektaLogger;
+    protected UrlInterface $url;
 
     /**
      * ConfigProvider constructor.
@@ -32,11 +36,15 @@ class ConfigProvider implements ConfigProviderInterface
      * @param UrlInterface $url
      */
     public function __construct(
-        protected ConektaHelper $conektaHelper,
-        protected Session $checkoutSession,
-        protected ConektaLogger $conektaLogger,
-        protected UrlInterface $url
+        ConektaHelper $conektaHelper,
+        Session $checkoutSession,
+        ConektaLogger $conektaLogger,
+        UrlInterface $url
     ) {
+        $this->url = $url;
+        $this->conektaLogger = $conektaLogger;
+        $this->checkoutSession = $checkoutSession;
+        $this->conektaHelper = $conektaHelper;
     }
 
     /**

--- a/Model/Ui/Oxxo/ConfigProvider.php
+++ b/Model/Ui/Oxxo/ConfigProvider.php
@@ -12,6 +12,9 @@ use Magento\Quote\Model\Quote;
 class ConfigProvider implements ConfigProviderInterface
 {
     public const CODE = 'conekta_oxxo';
+    protected Session $checkoutSession;
+    protected Repository $assetRepository;
+    protected ConektaHelper $conektaHelper;
 
     /**
      * @param Session $checkoutSession
@@ -19,10 +22,13 @@ class ConfigProvider implements ConfigProviderInterface
      * @param ConektaHelper $conektaHelper
      */
     public function __construct(
-        protected Session $checkoutSession,
-        protected Repository $assetRepository,
-        protected ConektaHelper $conektaHelper
+        Session $checkoutSession,
+        Repository $assetRepository,
+        ConektaHelper $conektaHelper
     ) {
+        $this->conektaHelper = $conektaHelper;
+        $this->assetRepository = $assetRepository;
+        $this->checkoutSession = $checkoutSession;
     }
 
     /**

--- a/Model/Ui/Spei/ConfigProvider.php
+++ b/Model/Ui/Spei/ConfigProvider.php
@@ -12,6 +12,9 @@ use Magento\Quote\Model\Quote;
 class ConfigProvider implements ConfigProviderInterface
 {
     public const CODE = 'conekta_spei';
+    protected ConektaHelper $conektaHelper;
+    protected Repository $assetRepository;
+    protected Session $checkoutSession;
 
     /**
      * @param Session $checkoutSession
@@ -19,10 +22,13 @@ class ConfigProvider implements ConfigProviderInterface
      * @param ConektaHelper $conektaHelper
      */
     public function __construct(
-        protected Session $checkoutSession,
-        protected Repository $assetRepository,
-        protected ConektaHelper $conektaHelper
+        Session $checkoutSession,
+        Repository $assetRepository,
+        ConektaHelper $conektaHelper
     ) {
+        $this->checkoutSession = $checkoutSession;
+        $this->assetRepository = $assetRepository;
+        $this->conektaHelper = $conektaHelper;
     }
 
     /**

--- a/Model/WebhookRepository.php
+++ b/Model/WebhookRepository.php
@@ -13,6 +13,13 @@ use Magento\Sales\Model\Service\InvoiceService;
 
 class WebhookRepository
 {
+    protected Transaction $transaction;
+    protected InvoiceSender $invoiceSender;
+    protected InvoiceService $invoiceService;
+    protected OrderInterface $orderInterface;
+    private ConektaSalesOrderInterface $conektaOrderSalesInterface;
+    private ConektaLogger $conektaLogger;
+
     /**
      * @param OrderInterface $orderInterface
      * @param InvoiceService $invoiceService
@@ -22,13 +29,19 @@ class WebhookRepository
      * @param ConektaSalesOrderInterface $conektaOrderSalesInterface
      */
     public function __construct(
-        protected OrderInterface $orderInterface,
-        protected InvoiceService $invoiceService,
-        protected InvoiceSender $invoiceSender,
-        protected Transaction $transaction,
-        private ConektaLogger $conektaLogger,
-        private ConektaSalesOrderInterface $conektaOrderSalesInterface
+        OrderInterface $orderInterface,
+        InvoiceService $invoiceService,
+        InvoiceSender $invoiceSender,
+        Transaction $transaction,
+        ConektaLogger $conektaLogger,
+        ConektaSalesOrderInterface $conektaOrderSalesInterface
     ) {
+        $this->orderInterface = $orderInterface;
+        $this->invoiceService = $invoiceService;
+        $this->invoiceSender = $invoiceSender;
+        $this->transaction = $transaction;
+        $this->conektaLogger = $conektaLogger;
+        $this->conektaOrderSalesInterface = $conektaOrderSalesInterface;
     }
 
     /**

--- a/Observer/DataAssignObserver.php
+++ b/Observer/DataAssignObserver.php
@@ -41,13 +41,15 @@ class DataAssignObserver extends AbstractDataAssignObserver
         self::TXN_ID,
         self::REFERENCE,
     ];
+    protected Session $checkoutSession;
 
     /**
      * @param Session $checkoutSession
      */
     public function __construct(
-        protected Session $checkoutSession
+        Session $checkoutSession
     ) {
+        $this->checkoutSession = $checkoutSession;
     }
 
     /**

--- a/Observer/Webhook.php
+++ b/Observer/Webhook.php
@@ -12,14 +12,19 @@ use Magento\Framework\Validator\Exception;
  */
 class Webhook implements ObserverInterface
 {
+    protected ManagerInterface $messageManager;
+    protected Config $config;
+
     /**
      * @param Config $config
      * @param ManagerInterface $messageManager
      */
     public function __construct(
-        protected Config $config,
-        protected ManagerInterface $messageManager
+        Config $config,
+        ManagerInterface $messageManager
     ) {
+        $this->config = $config;
+        $this->messageManager = $messageManager;
     }
 
     /**

--- a/Setup/Patch/Data/AddCustomerConektaAttr.php
+++ b/Setup/Patch/Data/AddCustomerConektaAttr.php
@@ -11,15 +11,20 @@ use Magento\Framework\Setup\Patch\{DataPatchInterface, PatchInterface};
 
 class AddCustomerConektaAttr implements DataPatchInterface
 {
+    protected CustomerSetupFactory $customerSetupFactory;
+    protected ModuleDataSetupInterface $moduleDataSetup;
+
     /**
      * AddCustomerErpCustomerIdAttribute constructor.
      * @param ModuleDataSetupInterface $moduleDataSetup
      * @param CustomerSetupFactory $customerSetupFactory
      */
     public function __construct(
-        protected ModuleDataSetupInterface $moduleDataSetup,
-        protected CustomerSetupFactory $customerSetupFactory
+        ModuleDataSetupInterface $moduleDataSetup,
+        CustomerSetupFactory $customerSetupFactory
     ) {
+        $this->moduleDataSetup = $moduleDataSetup;
+        $this->customerSetupFactory = $customerSetupFactory;
     }
 
     /**

--- a/etc/db_schema.xml
+++ b/etc/db_schema.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <schema xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:framework:Setup/Declaration/Schema/etc/schema.xsd">
-    <table name="conekta_salesorder" resorce="default" engine="innodb" comment="Conekta payments orders">
+    <table name="conekta_salesorder" resource="default" engine="innodb" comment="Conekta payments orders">
         <column xsi:type="int" name="id" nullable="false" unsigned="true" identity="true"
                 comment="Conekta Sales Orders ID"/>
         <column xsi:type="varchar" name="conekta_order_id" nullable="false" length="255" comment="Conekta Order"/>
@@ -19,7 +19,7 @@
             <column name="increment_order_id"/>
         </constraint>
     </table>
-    <table name="conekta_quote" resorce="default" engine="innodb" comment="Map Table Conekta Orders and Quotes">
+    <table name="conekta_quote" resource="default" engine="innodb" comment="Map Table Conekta Orders and Quotes">
         <column xsi:type="int" name="quote_id" nullable="false" unsigned="true" identity="true"
                 comment="Conekta Quote ID"/>
         <column xsi:type="varchar" name="conekta_order_id" nullable="false" length="255" comment="Conekta Order"/>


### PR DESCRIPTION
This commit brings some sugestions to make the plugin backward compatible with PHP 7.4.

With this changes, the module could be installed in version 2.4.2 of Magento, apparently with no problems. Please, consider analysing and testing this commit to be incorporate into main branch, or in a version for version 7.4 of PHP.

Thanks in advance,

[]'s